### PR TITLE
Add limit to GitHub Actions PRs only

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,13 @@ runs:
           } else {
             ## Check if PR opened by Dependabot ##
             if (context.payload.sender.login == 'dependabot[bot]') {
-              core.info("Processing the Pull Request...")
-              return true;
+              ## Check if Dependabot PR is for GitHub Actions ##
+              if (context.payload.pull_request.labels.includes('github-actions') {
+                core.info("Processing the Pull Request...")
+                return true;
+              } else {
+                core.info("Not a GitHub Actions Dependabot Pull Request.");
+              }
             } else {
               core.info("Not a Dependabot Pull Request.");
             }


### PR DESCRIPTION
Before this would check every type of Dependabot PR, but most others have a different format and would fail.

This limits the action to only run when it is a Dependabot PR for GitHub Actions.