### PR TITLE
feat: remove `pull_request_target`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Tim Jonas Meinerzhagen
+Copyright (c) 2021-2022 Tim Jonas Meinerzhagen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: timmeinerzhagen/dependabot-sha-comment-action@main # insert current version
         with:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
 ## Security Disclaimer
@@ -41,7 +41,7 @@ In order to run this action you also need to provide a PAT. This is needed becau
 
 ## Inputs
 
-### GITHUB_TOKEN *required*
+### GH_TOKEN *required*
 
 A GitHub Personal Access Token (PAT) is required. 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This makes the actions much more readable than having a plain SHA.
 Resulting versioning style:
 
 ```
-- uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+- uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 ```
 
 Scope:
@@ -20,8 +20,10 @@ To get frequent Dependabot updates add an [`.github/dependabot.yml`](https://doc
 
 ## Example usage
 
+You need to add `GH_TOKEN` to the Dependabot Secrets of your repositories.
+
 ```
-on: [pull_request_target]
+on: [pull_request]
 jobs:
   sha-comment:
     runs-on: ubuntu-latest
@@ -31,22 +33,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
-## Security Disclaimer
-
-This action uses the `pull_request_target` and an additional PAT. Why?
-
-Only the trigger `pull_request_target` allows having write privileges in a Dependabot Pull Request, as those are treated as PRs from a Fork. See the concerns with the usage of this trigger in the GitHub Security Lab blogpost [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). As this action only looks at the PR DIFF and adjusts the updated file, arbitrary code execution is not an issue, as stated in the post. 
-
-In order to run this action you also need to provide a PAT. This is needed because you can't give the included GitHub Actions token the permissions to change GitHub Actions workflow files. This is specifically not included in the list of possible permissions and as such requires use of a PAT with the `repo` and `workflows` permissions.
-
 ## Inputs
 
 ### GH_TOKEN *required*
 
-A GitHub Personal Access Token (PAT) is required. 
+A GitHub Personal Access Token (PAT) is required. You need to add this token to the Dependabot Secrets of your repository, so that workflows triggered by Dependabot Pull Requests can receive it.
 
 This PAT needs the access scopes `repo` and `workflows` to push changes to GitHub Actions workflows. 
-See the [Security Disclaimer](#Security-Disclaimer).
+The `workflow` permission can't be given to the default repository token, which is why this token needs to be provided in addition.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -28,10 +28,9 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       with:
-        github-token: ${{ github.token }}
         script: |
           // Check if correct event //
-          if ( !(context.eventName == 'pull_request_target' || context.eventName == 'pull_request) ) {
+          if ( !(context.eventName == 'pull_request_target' || context.eventName == 'pull_request') ) {
             core.setFailed("This action can only be used with the 'pull_request_target' or 'pull_request' trigger.");
           } else {
             // Check if PR opened by Dependabot //

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       with:
-        token: ${{ github.token }}
+        github-token: ${{ github.token }}
         script: |
           // Check if correct event //
           if ( !(context.eventName == 'pull_request_target' || context.eventName == 'pull_request) ) {

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       with:
+        token: ${{ github.token }}
         script: |
           // Check if correct event //
           if ( !(context.eventName == 'pull_request_target' || context.eventName == 'pull_request) ) {

--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,8 @@ runs:
       with:
         script: |
           // Check if correct event //
-          if ( !(context.eventName == 'pull_request_target' || context.eventName == 'pull_request') ) {
-            core.setFailed("This action can only be used with the 'pull_request_target' or 'pull_request' trigger.");
+          if (!context.eventName == 'pull_request') {
+            core.setFailed("This action can only be used with the 'pull_request' trigger.");
           } else {
             // Check if PR opened by Dependabot //
             if (context.payload.sender.login == 'dependabot[bot]') {

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Dependabot SHA Comment Action'
 description: 'Update version comment for SHA pin of GitHub Actions on Dependabot update.'
 author: timmeinerzhagen
 inputs: 
-  GITHUB_TOKEN:
+  GH_TOKEN:
     description: 'Github token of the repository with scopes repos and workflows'
     required: false
   FORMAT_TAG:
@@ -20,13 +20,13 @@ runs:
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.event.pull_request.head.ref }}
-        token: ${{ inputs.GITHUB_TOKEN || github.token }}
+        token: ${{ inputs.GH_TOKEN || github.token }}
         
     - name: Check Pull Request Meta
       uses: actions/github-script@v5
       id: check
       env:
-        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
       with:
         script: |
           // Check if correct event //
@@ -39,7 +39,7 @@ runs:
                 core.info("Processing the Pull Request...")
                 return true;
               } else {
-                core.setFailed("The required parameter 'GITHUB_TOKEN' is not provided.");
+                core.setFailed("The required parameter 'GH_TOKEN' is not provided.");
               }
             } else {
               core.info("Not a Dependabot Pull Request.");


### PR DESCRIPTION
* Remove the option to use unsafe `pull_request_target` 
* Adjust flow to make use of Dependabot Secrets
* Make `GH_TOKEN` optional for non Dependabot PRs to allow use of Dependabot Secrets